### PR TITLE
fix: clamp haversine formula

### DIFF
--- a/App.js
+++ b/App.js
@@ -56,7 +56,8 @@ function distanceMeters(a, b) {
   const la1 = toRad(a.latitude);
   const la2 = toRad(b.latitude);
   const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
-  return 2 * R * Math.asin(Math.sqrt(h));
+  // floating point errors can push h slightly above 1, which breaks asin
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
 // normalizace textu (bez diakritiky)


### PR DESCRIPTION
## Summary
- avoid NaN in distance calculations by clamping haversine value before `asin`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689668f1dfb88322bf774bac1cd827f6